### PR TITLE
Allowing forward differentiation

### DIFF
--- a/src/boost_fractor_transformer.jl
+++ b/src/boost_fractor_transformer.jl
@@ -272,7 +272,7 @@ end
 """
 Transformer Algorithm using Transfer Matrices and Modes to do the 3D Calculation.
 """
-function transformer(bdry::SetupBoundaries, coords::CoordinateSystem, modes::Modes; f=10.0e9, velocity_x=0, prop=propagator, propagation_matrices::Array{Array{Complex{T},2}}=nothing, diskR=0.15, emit=axion_induced_modes(coords,modes;B=nothing,velocity_x=velocity_x,diskR=diskR), reflect=nothing) where T<:Real
+function transformer(bdry::SetupBoundaries, coords::CoordinateSystem, modes::Modes; f=10.0e9, velocity_x=0, prop=propagator, propagation_matrices::Array{Array{Complex{T},2},1}=Array{Complex{Float64},2}[], diskR=0.15, emit=axion_induced_modes(coords,modes;B=nothing,velocity_x=velocity_x,diskR=diskR), reflect=nothing) where T<:Real
     # For the transformer the region of the mirror must contain a high dielectric constant,
     # as the mirror is not explicitly taken into account
     # To have same SetupBoundaries object for all codes and cheerleader assumes NaN, just define a high constant
@@ -284,7 +284,9 @@ function transformer(bdry::SetupBoundaries, coords::CoordinateSystem, modes::Mod
 
     initial = emit
     #println(initial)
+
     axion_beam = Array{Complex{T}}(zeros((modes.M)*(2modes.L+1)))
+
     #println(axion_beam)
 
     #=
@@ -320,7 +322,7 @@ function transformer(bdry::SetupBoundaries, coords::CoordinateSystem, modes::Mod
         # calculate T_s^m ---------------------------
 
         # Propagation matrix (later become the subblocks of P)
-        diffprop = (propagation_matrices === nothing ?
+        diffprop = (isempty(propagation_matrices) ?
                         propagation_matrix(bdry.distance[idx_reg(s)], diskR, bdry.eps[idx_reg(s)], bdry.relative_tilt_x[idx_reg(s)], bdry.relative_tilt_y[idx_reg(s)], bdry.relative_surfaces[idx_reg(s),:,:], lambda, coords, modes; prop=prop) :
                         propagation_matrices[idx_reg(s)])
 

--- a/src/boost_fractor_transformer.jl
+++ b/src/boost_fractor_transformer.jl
@@ -230,7 +230,7 @@ end
 """
 Calculate Transfer matrix like in 4.9. 
 """
-function add_boundary(transm, n_left, n_right, diffprop, modes::Modes)
+function add_boundary(transm, n_left, n_right, diffprop::Array{Complex{T}}, modes::Modes) where T<:Real
     # We calculate G_r P_r analogous to eqs. 4.7
     # where n_right = n_{r+1}, n_left = n_r
 
@@ -238,7 +238,7 @@ function add_boundary(transm, n_left, n_right, diffprop, modes::Modes)
     G = (( (1. /(2*n_right)).*[(n_right+n_left)*modes.id (n_right-n_left)*modes.id ; (n_right-n_left)*modes.id (n_right+n_left)*modes.id] ))
 
     # The product, i.e. transfer matrix
-    transm *= G * [diffprop modes.zeromatrix; modes.zeromatrix inv(Array{Complex{Float64}}(diffprop))]
+    transm *= G * [diffprop modes.zeromatrix; modes.zeromatrix inv(Array{Complex{T}}(diffprop))]
   
     # Note: we build up the system from the end (Lm) downwards until L0
     # so this makes a transfer matrix from interface n -> m to a function that goes from interface n-1 ->m
@@ -272,7 +272,7 @@ end
 """
 Transformer Algorithm using Transfer Matrices and Modes to do the 3D Calculation.
 """
-function transformer(bdry::SetupBoundaries, coords::CoordinateSystem, modes::Modes; f=10.0e9, velocity_x=0, prop=propagator, propagation_matrices=nothing, diskR=0.15, emit=axion_induced_modes(coords,modes;B=nothing,velocity_x=velocity_x,diskR=diskR), reflect=nothing)
+function transformer(bdry::SetupBoundaries, coords::CoordinateSystem, modes::Modes; f=10.0e9, velocity_x=0, prop=propagator, propagation_matrices::Array{Array{Complex{T},2}}=nothing, diskR=0.15, emit=axion_induced_modes(coords,modes;B=nothing,velocity_x=velocity_x,diskR=diskR), reflect=nothing) where T<:Real
     # For the transformer the region of the mirror must contain a high dielectric constant,
     # as the mirror is not explicitly taken into account
     # To have same SetupBoundaries object for all codes and cheerleader assumes NaN, just define a high constant
@@ -284,7 +284,7 @@ function transformer(bdry::SetupBoundaries, coords::CoordinateSystem, modes::Mod
 
     initial = emit
     #println(initial)
-    axion_beam = Array{Complex{Float64}}(zeros((modes.M)*(2modes.L+1)))
+    axion_beam = Array{Complex{T}}(zeros((modes.M)*(2modes.L+1)))
     #println(axion_beam)
 
     #=


### PR DESCRIPTION
A few changes to allow ForwardDiff's dual numbers to propagate through transformer.  For a gradient w.r.t. disk distances, any variable that depends on the disk distances needs to be able to accomodate either Floats for a normal BF computation or Dual for gradient computation. Hence the more generic "T where T<:Real". 